### PR TITLE
Switch to license_files due to license_file deprecation

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,4 +2,4 @@
 universal=1
 
 [metadata]
-license_file = LICENSE
+license_files = LICENSE


### PR DESCRIPTION
The license_file parameter is deprecated, use license_files instead.

Fix the error:

```
/usr/lib/python3.12/site-packages/setuptools/config/setupcfg.py:293: _DeprecatedConfig: Deprecated config in `setup.cfg`
!!
        ********************************************************************************
        The license_file parameter is deprecated, use license_files instead.
        By 2023-Oct-30, you need to update your project and remove deprecated calls
        or your builds will no longer be supported.
        See https://setuptools.pypa.io/en/latest/userguide/declarative_config.html for details.
        ********************************************************************************
```